### PR TITLE
Community tech tree support

### DIFF
--- a/GameData/WildBlueIndustries/Buffalo/ModuleManagerPatches/Buffalo CTT Patch.cfg
+++ b/GameData/WildBlueIndustries/Buffalo/ModuleManagerPatches/Buffalo CTT Patch.cfg
@@ -1,0 +1,110 @@
+// Aero
+
+
+// ATV Seat
+@PART[WBI_ATVSeat]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = fieldScience
+}
+
+// AuxEN Buffalo Probe Core
+@PART[WBI_AuxEN]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = automation
+}
+
+// Buffalo Cab
+@PART[WBI_BuffalCab]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = specializedCommandModules
+}
+
+
+
+
+// Command
+
+
+// 
+@PART[]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = 
+}
+
+
+// Control
+
+
+// Electrical
+
+
+// Engine
+
+
+// WB22 Tilt-Rotor
+@PART[WBITiltRotor]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = specializedFlightSystems
+}
+
+// WB44 Tilt-Rotor
+@PART[WBITiltRotor]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = specializedFlightSystems
+}
+
+
+// FuelTank
+
+
+// Tundra 200
+@PART[WBI_Tundra200]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = storageTechnology
+}
+
+// Tundra 400
+@PART[WBI_Tundra400]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = storageTechnology
+}
+
+
+
+
+// JetWing
+
+
+// Outback
+
+
+// Payload
+
+
+// Structural
+
+
+// Utility
+
+
+// Ground Stabilizer
+@PART[WBI_BuffaloGroundStabilizer]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = advLanding
+}
+
+
+// Wheel
+
+
+// Bear Cub
+@PART[WBI_M1A0Wheel]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = fieldScience
+}
+
+// Mountain Goat Omni Wheel
+@PART[WBI_OmniWheel]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = advancedMotors
+}

--- a/GameData/WildBlueIndustries/Buffalo/ModuleManagerPatches/Buffalo CTT Patch.cfg
+++ b/GameData/WildBlueIndustries/Buffalo/ModuleManagerPatches/Buffalo CTT Patch.cfg
@@ -28,7 +28,7 @@
 // Buffalo Cab
 @PART[WBI_BuffaloCab]:NEEDS[CommunityTechTree]:FINAL
 {
-	@TechRequired = advExploration
+	@TechRequired = heavyCommandModules
 }
 
 
@@ -111,10 +111,16 @@
 // Payload
 
 
+// Cargo Ramp
+@PART[WBI_CargoRamp]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = logistics
+}
+
 // Flatbed 1
 @PART[WBI_Flatbed1uStd]:NEEDS[CommunityTechTree]:FINAL
 {
-	@TechRequired = advExploration
+	@TechRequired = fieldScience
 }
 
 // Fladbed Wide 1
@@ -126,13 +132,49 @@
 // Flatbed 2
 @PART[WBI_Flatbed2uStd]:NEEDS[CommunityTechTree]:FINAL
 {
-	@TechRequired = advExploration
+	@TechRequired = fieldScience
 }
 
 // Flatbed Wide 2
 @PART[WBI_Flatbed2uWide]:NEEDS[CommunityTechTree]:FINAL
 {
 	@TechRequired = logistics
+}
+
+// Half Service Bay
+@PART[WBI_HalfServiceBay]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = fieldScience
+}
+
+// Service Bay
+@PART[WBI_ServiceBay]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = logistics
+}
+
+// Solar Flatbed 1
+@PART[WBI_SolarFlatbed1u]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = advPVMaterials
+}
+
+// Wide Solar Fladbed 1
+@PART[WBI_SolarFlatbed1uWide]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = advPVMaterials
+}
+
+// Solar Flatbed 2
+@PART[WBI_SolarFlatbed2u]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = advPVMaterials
+}
+
+// Wide Solar Flatbed 2
+@PART[WBI_SolarFlatbed2uWide]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = advPVMaterials
 }
 
 
@@ -147,16 +189,40 @@
 	@TechRequired = specializedConstruction
 }
 
+// Aero Cone
+@PART[WBI_BuffaloAeroCone]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = specializedConstruction
+}
+
+// Aero Cone 1
+@PART[WBI_BuffaloAeroCone1]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = specializedConstruction
+}
+
+// Aero Cone 3
+@PART[WBI_BuffaloAeroCone3]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = specializedConstruction
+}
+
+// Aero Cone 4
+@PART[WBI_BuffaloAeroCone4]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = specializedConstruction
+}
+
 // Chassis 1
 @PART[WBI_Chassis1u]:NEEDS[CommunityTechTree]:FINAL
 {
-	@TechRequired = advExploration
+	@TechRequired = fieldScience
 }
 
 // Chassis 2
 @PART[WBI_Chassis2u]:NEEDS[CommunityTechTree]:FINAL
 {
-	@TechRequired = advExploration
+	@TechRequired = fieldScience
 }
 
 // Chassis 3
@@ -174,7 +240,7 @@
 // Chassis End
 @PART[WBI_ChassisEndu]:NEEDS[CommunityTechTree]:FINAL
 {
-	@TechRequired = advExploration
+	@TechRequired = fieldScience
 }
 
 // Slim Chassis
@@ -196,19 +262,21 @@
 }
 
 
+
+
 // Utility
 
 
 // Airlock Module
 @PART[WBI_BuffaloAirlock]:NEEDS[CommunityTechTree]:FINAL
 {
-	@TechRequired = fieldScience
+	@TechRequired = specializedCommandModules
 }
 
 // Crew Cab
 @PART[WBI_CrewCab]:NEEDS[CommunityTechTree]:FINAL
 {
-	@TechRequired = fieldScience
+	@TechRequired = heavyCommandModules
 }
 
 // Crew Cab Science Upgrade
@@ -232,7 +300,7 @@
 // Long Passenger Cabin
 @PART[WBI_LongPassengerCab]:NEEDS[CommunityTechTree]:FINAL
 {
-	@TechRequired = fieldScience
+	@TechRequired = specializedCommandModules
 }
 
 // Mineshaft
@@ -256,7 +324,7 @@
 // Short Passenger Cab
 @PART[WBI_ShortPassengerCab]:NEEDS[CommunityTechTree]:FINAL
 {
-	@TechRequired = advExploration
+	@TechRequired = specializedCommandModules
 }
 
 // Trailer Hitch

--- a/GameData/WildBlueIndustries/Buffalo/ModuleManagerPatches/Buffalo CTT Patch.cfg
+++ b/GameData/WildBlueIndustries/Buffalo/ModuleManagerPatches/Buffalo CTT Patch.cfg
@@ -1,6 +1,18 @@
 // Aero
 
 
+// 
+@PART[]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = 
+}
+
+
+
+
+// Command
+
+
 // ATV Seat
 @PART[WBI_ATVSeat]:NEEDS[CommunityTechTree]:FINAL
 {
@@ -14,22 +26,12 @@
 }
 
 // Buffalo Cab
-@PART[WBI_BuffalCab]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_BuffaloCab]:NEEDS[CommunityTechTree]:FINAL
 {
 	@TechRequired = specializedCommandModules
 }
 
 
-
-
-// Command
-
-
-// 
-@PART[]:NEEDS[CommunityTechTree]:FINAL
-{
-	@TechRequired = 
-}
 
 
 // Control
@@ -48,7 +50,7 @@
 }
 
 // WB44 Tilt-Rotor
-@PART[WBITiltRotor]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBITiltRotor2]:NEEDS[CommunityTechTree]:FINAL
 {
 	@TechRequired = specializedFlightSystems
 }
@@ -60,13 +62,13 @@
 // Tundra 200
 @PART[WBI_Tundra200]:NEEDS[CommunityTechTree]:FINAL
 {
-	@TechRequired = storageTechnology
+	@TechRequired = storageTech
 }
 
 // Tundra 400
 @PART[WBI_Tundra400]:NEEDS[CommunityTechTree]:FINAL
 {
-	@TechRequired = storageTechnology
+	@TechRequired = storageTech
 }
 
 

--- a/GameData/WildBlueIndustries/Buffalo/ModuleManagerPatches/Buffalo CTT Patch.cfg
+++ b/GameData/WildBlueIndustries/Buffalo/ModuleManagerPatches/Buffalo CTT Patch.cfg
@@ -165,7 +165,35 @@
 // JetWing
 
 
+// Jetwing
+@PART[WBI_JetWing]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = nanolathing
+}
+
+// Jump Chute
+@PART[WBI_JumpChute]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = enhancedSurvivability
+}
+
+// Micro Jet Engine
+@PART[WBI_MicroJetEngine]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = nanolathing
+}
+
+
+
+
 // Outback
+
+@PART[WBI_Outback]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = spaceExploration
+}
+
+
 
 
 // Payload

--- a/GameData/WildBlueIndustries/Buffalo/ModuleManagerPatches/Buffalo CTT Patch.cfg
+++ b/GameData/WildBlueIndustries/Buffalo/ModuleManagerPatches/Buffalo CTT Patch.cfg
@@ -37,6 +37,15 @@
 // Control
 
 
+// RCS Module
+@PART[WBI_RCSModule]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = specializedCommandModules
+}
+
+
+
+
 // Electrical
 
 
@@ -132,6 +141,12 @@
 // Structural
 
 
+// Buffalo Adapter
+@PART[WBI_BuffaloAdapter]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = specializedConstruction
+}
+
 // Chassis 1
 @PART[WBI_Chassis1u]:NEEDS[CommunityTechTree]:FINAL
 {
@@ -150,10 +165,22 @@
 	@TechRequired = specializedConstruction
 }
 
+// Chassis Decoupler
+@PART[WBI_ChassisDecoupler]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = specializedConstruction
+}
+
 // Chassis End
 @PART[WBI_ChassisEndu]:NEEDS[CommunityTechTree]:FINAL
 {
 	@TechRequired = advExploration
+}
+
+// Slim Chassis
+@PART[WBI_ChassisSlim2u]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = specializedConstruction
 }
 
 // Half Chassis
@@ -220,6 +247,12 @@
 	@TechRequired = specializedScienceTech
 }
 
+// SCP Adapter
+@PART[WBI_SCPAdapter]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = advConstruction
+}
+
 // Short Passenger Cab
 @PART[WBI_ShortPassengerCab]:NEEDS[CommunityTechTree]:FINAL
 {
@@ -228,6 +261,18 @@
 
 // Trailer Hitch
 @PART[WBI_TrailerHitch2]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = specializedConstruction
+}
+
+// Wagon
+@PART[WBI_Wagon2u]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = logistics
+}
+
+// Wheel Jack
+@PART[WBI_WheelJack]:NEEDS[CommunityTechTree]:FINAL
 {
 	@TechRequired = specializedConstruction
 }

--- a/GameData/WildBlueIndustries/Buffalo/ModuleManagerPatches/Buffalo CTT Patch.cfg
+++ b/GameData/WildBlueIndustries/Buffalo/ModuleManagerPatches/Buffalo CTT Patch.cfg
@@ -28,7 +28,7 @@
 // Buffalo Cab
 @PART[WBI_BuffaloCab]:NEEDS[CommunityTechTree]:FINAL
 {
-	@TechRequired = specializedCommandModules
+	@TechRequired = advExploration
 }
 
 
@@ -102,11 +102,87 @@
 // Payload
 
 
+// Flatbed 1
+@PART[WBI_Flatbed1uStd]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = advExploration
+}
+
+// Fladbed Wide 1
+@PART[WBI_Flatbed1uWide]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = logistics
+}
+
+// Flatbed 2
+@PART[WBI_Flatbed2uStd]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = advExploration
+}
+
+// Flatbed Wide 2
+@PART[WBI_Flatbed2uWide]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = logistics
+}
+
+
+
+
 // Structural
+
+
+// Chassis 1
+@PART[WBI_Chassis1u]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = advExploration
+}
+
+// Chassis 2
+@PART[WBI_Chassis2u]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = advExploration
+}
+
+// Chassis 3
+@PART[WBI_Chassis3u]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = specializedConstruction
+}
+
+// Chassis End
+@PART[WBI_ChassisEndu]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = advExploration
+}
+
+// Half Chassis
+@PART[WBI_HalfChassis]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = precisionEngineering
+}
+
+// Quarter Chassis
+@PART[WBI_QuarterChassis]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = precisionEngineering
+}
 
 
 // Utility
 
+
+// Airlock Module
+@PART[WBI_BuffaloAirlock]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = fieldScience
+}
+
+// Crew Cab
+@PART[WBI_CrewCab]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = fieldScience
+}
 
 // Crew Cab Science Upgrade
 @PARTUPGRADE[CrewCabScienceUpgrade]:NEEDS[CommunityTechTree]:FINAL
@@ -120,16 +196,16 @@
 	@TechRequired = advActuators
 }
 
-// ARCS Scaner Arm
-@PART[WBI_ScannerArm]:NEEDS[CommunityTechTree]:FINAL
-{
-	@TechRequired = specializedScienceTech
-}
-
 // Ground Stabilizer
 @PART[WBI_BuffaloGroundStabilizer]:NEEDS[CommunityTechTree]:FINAL
 {
 	@TechRequired = advLanding
+}
+
+// Long Passenger Cabin
+@PART[WBI_LongPassengerCab]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = fieldScience
 }
 
 // Mineshaft
@@ -137,6 +213,26 @@
 {
 	@TechRequired = metaMaterials
 }
+
+// ARCS Scaner Arm
+@PART[WBI_ScannerArm]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = specializedScienceTech
+}
+
+// Short Passenger Cab
+@PART[WBI_ShortPassengerCab]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = advExploration
+}
+
+// Trailer Hitch
+@PART[WBI_TrailerHitch2]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = specializedConstruction
+}
+
+
 
 
 // Wheel

--- a/GameData/WildBlueIndustries/Buffalo/ModuleManagerPatches/Buffalo CTT Patch.cfg
+++ b/GameData/WildBlueIndustries/Buffalo/ModuleManagerPatches/Buffalo CTT Patch.cfg
@@ -40,6 +40,25 @@
 // Electrical
 
 
+// Flex Fuel Power Pack
+@PART[WBI_BuffaloPowerPack]:NEEDS[CommunityTechTree]:FINAL
+{
+//	@TechRequired = specializedElectrics
+}
+
+// GTG125 Gas Turbine
+@PART[GasTurbineGenerator]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = largeElectrics
+}
+
+// GTG250 Gas Turbine
+@PART[GasTurbineGenerator2]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = specializedElectrics
+}
+
+
 // Engine
 
 
@@ -89,10 +108,34 @@
 // Utility
 
 
+// Crew Cab Science Upgrade
+@PARTUPGRADE[CrewCabScienceUpgrade]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = specializedScienceTech
+}
+
+// Grappler Arm
+@PART[WBI_GrapplerArm]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = advActuators
+}
+
+// ARCS Scaner Arm
+@PART[WBI_ScannerArm]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = specializedScienceTech
+}
+
 // Ground Stabilizer
 @PART[WBI_BuffaloGroundStabilizer]:NEEDS[CommunityTechTree]:FINAL
 {
 	@TechRequired = advLanding
+}
+
+// Mineshaft
+@PART[WBI_Mineshaft]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = metaMaterials
 }
 
 

--- a/GameData/WildBlueIndustries/Buffalo/ModuleManagerPatches/Buffalo CTT Patch.cfg
+++ b/GameData/WildBlueIndustries/Buffalo/ModuleManagerPatches/Buffalo CTT Patch.cfg
@@ -1,62 +1,56 @@
 // Aero
 
 
-// 
-@PART[]:NEEDS[CommunityTechTree]:FINAL
-{
-	@TechRequired = 
-}
-
 // Buffalo Canard
-@PART[BuffaloCanard]:NEEDS[CommunityTechTree]:FINAL
+@PART[BuffaloCanard]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = aerospaceComposites
 }
 
 // Buffallo Elevon 1
-@PART[BuffaloElevon1]:NEEDS[CommunityTechTree]:FINAL
+@PART[BuffaloElevon1]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = aerospaceComposites
 }
 
 // Buffalo Saddle Tank
-@PART[WBI_BuffaloSaddleTank]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_BuffaloSaddleTank]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = storageTech
 }
 
 // Buffalo Winglet
-@PART[BuffaloWinglet]:NEEDS[CommunityTechTree]:FINAL
+@PART[BuffaloWinglet]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = aerospaceComposites
 }
 
 // Buffalo Wing 1
-@PART[WBI_BuffaloWingType1]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_BuffaloWingType1]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = aerospaceComposites
 }
 
 // Buffalo Wing 2
-@PART[WBI_BuffaloWingType2]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_BuffaloWingType2]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = aerospaceComposites
 }
 
 // Buffalo Wing 3
-@PART[WBI_BuffaloWingType3]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_BuffaloWingType3]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = aerospaceComposites
 }
 
 // Buffalo Wing 4
-@PART[WBI_BuffaloWingType4]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_BuffaloWingType4]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = aerospaceComposites
 }
 
 // Buffalo Wing Root
-@PART[WBI_WingRoot]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_WingRoot]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = aerospaceComposites
 }
@@ -68,19 +62,19 @@
 
 
 // ATV Seat
-@PART[WBI_ATVSeat]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_ATVSeat]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = fieldScience
 }
 
 // AuxEN Buffalo Probe Core
-@PART[WBI_AuxEN]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_AuxEN]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = automation
 }
 
 // Buffalo Cab
-@PART[WBI_BuffaloCab]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_BuffaloCab]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = heavyCommandModules
 }
@@ -92,13 +86,13 @@
 
 
 // Buffalo SAS
-@PART[WBI_BuffaloSAS]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_BuffaloSAS]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = specializedCommandModules
 }
 
 // RCS Module
-@PART[WBI_RCSModule]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_RCSModule]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = specializedCommandModules
 }
@@ -110,19 +104,19 @@
 
 
 // Flex Fuel Power Pack
-@PART[WBI_BuffaloPowerPack]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_BuffaloPowerPack]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = specializedElectrics
 }
 
 // GTG125 Gas Turbine
-@PART[GasTurbineGenerator]:NEEDS[CommunityTechTree]:FINAL
+@PART[GasTurbineGenerator]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = largeElectrics
 }
 
 // GTG250 Gas Turbine
-@PART[GasTurbineGenerator2]:NEEDS[CommunityTechTree]:FINAL
+@PART[GasTurbineGenerator2]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = specializedElectrics
 }
@@ -132,13 +126,13 @@
 
 
 // WB22 Tilt-Rotor
-@PART[WBITiltRotor]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBITiltRotor]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = specializedFlightSystems
 }
 
 // WB44 Tilt-Rotor
-@PART[WBITiltRotor2]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBITiltRotor2]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = specializedFlightSystems
 }
@@ -148,13 +142,13 @@
 
 
 // Tundra 200
-@PART[WBI_Tundra200]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_Tundra200]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = storageTech
 }
 
 // Tundra 400
-@PART[WBI_Tundra400]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_Tundra400]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = storageTech
 }
@@ -166,19 +160,19 @@
 
 
 // Jetwing
-@PART[WBI_JetWing]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_JetWing]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = nanolathing
 }
 
 // Jump Chute
-@PART[WBI_JumpChute]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_JumpChute]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = enhancedSurvivability
 }
 
 // Micro Jet Engine
-@PART[WBI_MicroJetEngine]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_MicroJetEngine]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = nanolathing
 }
@@ -188,7 +182,7 @@
 
 // Outback
 
-@PART[WBI_Outback]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_Outback]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = spaceExploration
 }
@@ -200,67 +194,67 @@
 
 
 // Cargo Ramp
-@PART[WBI_CargoRamp]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_CargoRamp]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = logistics
 }
 
 // Flatbed 1
-@PART[WBI_Flatbed1uStd]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_Flatbed1uStd]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = fieldScience
 }
 
 // Fladbed Wide 1
-@PART[WBI_Flatbed1uWide]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_Flatbed1uWide]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = logistics
 }
 
 // Flatbed 2
-@PART[WBI_Flatbed2uStd]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_Flatbed2uStd]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = fieldScience
 }
 
 // Flatbed Wide 2
-@PART[WBI_Flatbed2uWide]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_Flatbed2uWide]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = logistics
 }
 
 // Half Service Bay
-@PART[WBI_HalfServiceBay]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_HalfServiceBay]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = storageTech
 }
 
 // Service Bay
-@PART[WBI_ServiceBay]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_ServiceBay]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = logistics
 }
 
 // Solar Flatbed 1
-@PART[WBI_SolarFlatbed1u]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_SolarFlatbed1u]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = advPVMaterials
 }
 
 // Wide Solar Fladbed 1
-@PART[WBI_SolarFlatbed1uWide]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_SolarFlatbed1uWide]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = advPVMaterials
 }
 
 // Solar Flatbed 2
-@PART[WBI_SolarFlatbed2u]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_SolarFlatbed2u]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = advPVMaterials
 }
 
 // Wide Solar Flatbed 2
-@PART[WBI_SolarFlatbed2uWide]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_SolarFlatbed2uWide]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = advPVMaterials
 }
@@ -272,79 +266,79 @@
 
 
 // Buffalo Adapter
-@PART[WBI_BuffaloAdapter]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_BuffaloAdapter]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = specializedConstruction
 }
 
 // Aero Cone
-@PART[WBI_BuffaloAeroCone]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_BuffaloAeroCone]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = specializedConstruction
 }
 
 // Aero Cone 1
-@PART[WBI_BuffaloAeroCone1]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_BuffaloAeroCone1]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = specializedConstruction
 }
 
 // Aero Cone 3
-@PART[WBI_BuffaloAeroCone3]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_BuffaloAeroCone3]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = specializedConstruction
 }
 
 // Aero Cone 4
-@PART[WBI_BuffaloAeroCone4]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_BuffaloAeroCone4]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = specializedConstruction
 }
 
 // Chassis 1
-@PART[WBI_Chassis1u]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_Chassis1u]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = fieldScience
 }
 
 // Chassis 2
-@PART[WBI_Chassis2u]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_Chassis2u]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = fieldScience
 }
 
 // Chassis 3
-@PART[WBI_Chassis3u]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_Chassis3u]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = specializedConstruction
 }
 
 // Chassis Decoupler
-@PART[WBI_ChassisDecoupler]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_ChassisDecoupler]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = specializedConstruction
 }
 
 // Chassis End
-@PART[WBI_ChassisEndu]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_ChassisEndu]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = fieldScience
 }
 
 // Slim Chassis
-@PART[WBI_ChassisSlim2u]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_ChassisSlim2u]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = specializedConstruction
 }
 
 // Half Chassis
-@PART[WBI_HalfChassis]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_HalfChassis]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = precisionEngineering
 }
 
 // Quarter Chassis
-@PART[WBI_QuarterChassis]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_QuarterChassis]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = precisionEngineering
 }
@@ -356,79 +350,79 @@
 
 
 // Airlock Module
-@PART[WBI_BuffaloAirlock]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_BuffaloAirlock]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = specializedCommandModules
 }
 
 // Crew Cab
-@PART[WBI_CrewCab]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_CrewCab]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = heavyCommandModules
 }
 
 // Crew Cab Science Upgrade
-@PARTUPGRADE[CrewCabScienceUpgrade]:NEEDS[CommunityTechTree]:FINAL
+@PARTUPGRADE[CrewCabScienceUpgrade]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = specializedScienceTech
 }
 
 // Grappler Arm
-@PART[WBI_GrapplerArm]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_GrapplerArm]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = advActuators
 }
 
 // Ground Stabilizer
-@PART[WBI_BuffaloGroundStabilizer]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_BuffaloGroundStabilizer]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = advLanding
 }
 
 // Long Passenger Cabin
-@PART[WBI_LongPassengerCab]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_LongPassengerCab]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = specializedCommandModules
 }
 
 // Mineshaft
-@PART[WBI_Mineshaft]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_Mineshaft]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = metaMaterials
 }
 
 // ARCS Scaner Arm
-@PART[WBI_ScannerArm]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_ScannerArm]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = specializedScienceTech
 }
 
 // SCP Adapter
-@PART[WBI_SCPAdapter]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_SCPAdapter]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = advConstruction
 }
 
 // Short Passenger Cab
-@PART[WBI_ShortPassengerCab]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_ShortPassengerCab]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = specializedCommandModules
 }
 
 // Trailer Hitch
-@PART[WBI_TrailerHitch2]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_TrailerHitch2]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = specializedConstruction
 }
 
 // Wagon
-@PART[WBI_Wagon2u]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_Wagon2u]:NEEDS[CommunityTechTree]:
 {
 	@TechRequired = logistics
 }
 
 // Wheel Jack
-@PART[WBI_WheelJack]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_WheelJack]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = specializedConstruction
 }
@@ -440,13 +434,13 @@
 
 
 // Bear Cub
-@PART[WBI_M1A0Wheel]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_M1A0Wheel]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = fieldScience
 }
 
 // Mountain Goat Omni Wheel
-@PART[WBI_OmniWheel]:NEEDS[CommunityTechTree]:FINAL
+@PART[WBI_OmniWheel]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = advancedMotors
 }

--- a/GameData/WildBlueIndustries/Buffalo/ModuleManagerPatches/Buffalo CTT Patch.cfg
+++ b/GameData/WildBlueIndustries/Buffalo/ModuleManagerPatches/Buffalo CTT Patch.cfg
@@ -7,6 +7,60 @@
 	@TechRequired = 
 }
 
+// Buffalo Canard
+@PART[BuffaloCanard]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = aerospaceComposites
+}
+
+// Buffallo Elevon 1
+@PART[BuffaloElevon1]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = aerospaceComposites
+}
+
+// Buffalo Saddle Tank
+@PART[WBI_BuffaloSaddleTank]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = storageTech
+}
+
+// Buffalo Winglet
+@PART[BuffaloWinglet]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = aerospaceComposites
+}
+
+// Buffalo Wing 1
+@PART[WBI_BuffaloWingType1]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = aerospaceComposites
+}
+
+// Buffalo Wing 2
+@PART[WBI_BuffaloWingType2]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = aerospaceComposites
+}
+
+// Buffalo Wing 3
+@PART[WBI_BuffaloWingType3]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = aerospaceComposites
+}
+
+// Buffalo Wing 4
+@PART[WBI_BuffaloWingType4]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = aerospaceComposites
+}
+
+// Buffalo Wing Root
+@PART[WBI_WingRoot]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = aerospaceComposites
+}
+
 
 
 
@@ -37,6 +91,12 @@
 // Control
 
 
+// Buffalo SAS
+@PART[WBI_BuffaloSAS]:NEEDS[CommunityTechTree]:FINAL
+{
+	@TechRequired = specializedCommandModules
+}
+
 // RCS Module
 @PART[WBI_RCSModule]:NEEDS[CommunityTechTree]:FINAL
 {
@@ -52,7 +112,7 @@
 // Flex Fuel Power Pack
 @PART[WBI_BuffaloPowerPack]:NEEDS[CommunityTechTree]:FINAL
 {
-//	@TechRequired = specializedElectrics
+	@TechRequired = specializedElectrics
 }
 
 // GTG125 Gas Turbine
@@ -144,7 +204,7 @@
 // Half Service Bay
 @PART[WBI_HalfServiceBay]:NEEDS[CommunityTechTree]:FINAL
 {
-	@TechRequired = fieldScience
+	@TechRequired = storageTech
 }
 
 // Service Bay


### PR DESCRIPTION
Buffalo is now moved up to various tech nodes around Field Science, to match the position of the stock rovers, and rovers of other mods.