### PR TITLE
Tweak Tundra 100/200 values to scale comparably

### DIFF
--- a/GameData/WildBlueIndustries/Buffalo/Parts/FuelTank/Tundra100.cfg
+++ b/GameData/WildBlueIndustries/Buffalo/Parts/FuelTank/Tundra100.cfg
@@ -17,7 +17,7 @@ PART
 	TechRequired = advConstruction
 	entryCost = 1900
 	cost = 800
-	category = Utility
+	category = FuelTank
 	subcategory = 0
 	title = Tundra 100
 	manufacturer = Wild Blue Industries
@@ -26,7 +26,7 @@ PART
 	attachRules = 1,0,1,1,0
 
 	// --- standard part parameters ---
-	mass = 0.175
+	mass = 0.0875
 	dragModelType = default
 	maximum_drag = 0.2
 	minimum_drag = 0.2
@@ -94,7 +94,7 @@ PART
 		isBreakable = false
 		resourceName = ElectricCharge
 		impactResistance = 20
-		chargeRate = 1.4
+		chargeRate = 0.7
 	}
 
 	RESOURCE

--- a/GameData/WildBlueIndustries/Buffalo/Parts/FuelTank/Tundra100.cfg
+++ b/GameData/WildBlueIndustries/Buffalo/Parts/FuelTank/Tundra100.cfg
@@ -15,8 +15,8 @@ PART
 	node_stack_back = 0, -0.212, 0, 0, -1, 0, 1
 
 	TechRequired = advConstruction
-	entryCost = 1900
-	cost = 800
+	entryCost = 950
+	cost = 400
 	category = FuelTank
 	subcategory = 0
 	title = Tundra 100

--- a/GameData/WildBlueIndustries/Buffalo/Parts/FuelTank/Tundra200.cfg
+++ b/GameData/WildBlueIndustries/Buffalo/Parts/FuelTank/Tundra200.cfg
@@ -42,7 +42,7 @@ PART
 	MODULE:NEEDS[KIS]
 	{
 		name = ModuleKISInventory
-		maxVolume = 200
+		maxVolume = 1500
 		externalAccess = true
 		internalAccess = true
 		slotsX = 4


### PR DESCRIPTION
As title, tweaking Tundra 100 values primarily, and also a couple Tundra 200 values, to be in-line with the 1-2-4 scaling expected as proceeding from Tundra 100-200-400 (similar to other fuel tanks).

(I made the changes online, and can't figure out how to `squash` them into one commit.)